### PR TITLE
Reformatted Changes file as per CPAN::Changes::Spec

### DIFF
--- a/Changes
+++ b/Changes
@@ -9,24 +9,24 @@ Revision history for Perl module Convert::BinHex
 
 1.118 unknown
 
-	- Ready to go public (with Paul's version, patched for native Mac support)!
-	- Warnings have been suppressed in a few places
+    - Ready to go public (with Paul's version, patched for native Mac support)!
+    - Warnings have been suppressed in a few places
       where undefined values appear.
 
 1.115 unknown
 
-	- Fixed another bug in comp2bin, related to the MARK falling on a
+    - Fixed another bug in comp2bin, related to the MARK falling on a
       boundary between inputs.  Added testing code.
 
 1.114 unknown
 
-	- Added BIN-to-HEX conversion.  Eh.  It's a start.
-	- Also, a lot of documentation additions and cleanups.
-	- Some methods were also renamed.
+    - Added BIN-to-HEX conversion.  Eh.  It's a start.
+    - Also, a lot of documentation additions and cleanups.
+    - Some methods were also renamed.
 
 1.103 unknown
-	- Fixed bug in decompression (wasn't saving last character).
-	- Fixed "NoComment" bug.
+    - Fixed bug in decompression (wasn't saving last character).
+    - Fixed "NoComment" bug.
 
 1.102 unknown
     - Initial release.


### PR DESCRIPTION
Hi Stephen :-)

I've reformatted your Changes file according to the spec in CPAN::Changes::Spec:
- Added entry for the release you just did
- Added a date for the last release ERYQ did. It looks like that might have been the only CPAN release, so I marked the others with 'unknown'. If you're sure they weren't released you could change them to 'not released' (see the [documentation](https://metacpan.org/module/BRICAS/CPAN-Changes-0.23/lib/CPAN/Changes/Spec.pod) for the special 'date tokens').
- Took out tab characters

Following this format means that various tools can more easily process your distribution automatically.

You can find out more about this at Brian Cassidy's [CPAN::Changes Kwalitee Service](http://changes.cpanhq.org), which is where I saw your module listed :-)

Note: at the moment the Kwalitee service isn't running the latest version of CPAN::Changes, so it will complain about 'unknown', but that will go away when the service is updated.

Cheers,
Neil

I'm doing this because I'm on a quest to help improve CPAN:

> http://questhub.io/realm/perl/quest/51f0337718ba7d3959000086

You can check the status of your Changes files for all dists:

> http://changes.cpanhq.org/author/STEPHEN

And then here's your [next quest](http://questhub.io/realm/perl/stencil/51e7022f7deb5b752c000004)! :-)
